### PR TITLE
Use dedicated Unix types for user and group

### DIFF
--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"regexp"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const qnameCharFmt string = "[A-Za-z0-9]"
@@ -197,16 +199,16 @@ const (
 	maxGroupID = math.MaxInt32
 )
 
-// IsValidGroupId tests that the argument is a valid Unix GID.
-func IsValidGroupId(gid int64) []string {
+// IsValidGroupID tests that the argument is a valid Unix GID.
+func IsValidGroupID(gid types.UnixGroupID) []string {
 	if minGroupID <= gid && gid <= maxGroupID {
 		return nil
 	}
 	return []string{InclusiveRangeError(minGroupID, maxGroupID)}
 }
 
-// IsValidUserId tests that the argument is a valid Unix UID.
-func IsValidUserId(uid int64) []string {
+// IsValidUserID tests that the argument is a valid Unix UID.
+func IsValidUserID(uid types.UnixUserID) []string {
 	if minUserID <= uid && uid <= maxUserID {
 		return nil
 	}

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -19,6 +19,8 @@ package validation
 import (
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestIsDNS1123Label(t *testing.T) {
@@ -154,33 +156,49 @@ func TestIsValidPortNum(t *testing.T) {
 	}
 }
 
-func TestIsValidGroupId(t *testing.T) {
-	goodValues := []int64{0, 1, 1000, 65535, 2147483647}
+func createGroupIDs(ids ...int64) []types.UnixGroupID {
+	var output []types.UnixGroupID
+	for _, id := range ids {
+		output = append(output, types.UnixGroupID(id))
+	}
+	return output
+}
+
+func createUserIDs(ids ...int64) []types.UnixUserID {
+	var output []types.UnixUserID
+	for _, id := range ids {
+		output = append(output, types.UnixUserID(id))
+	}
+	return output
+}
+
+func TestIsValidGroupID(t *testing.T) {
+	goodValues := createGroupIDs(0, 1, 1000, 65535, 2147483647)
 	for _, val := range goodValues {
-		if msgs := IsValidGroupId(val); len(msgs) != 0 {
+		if msgs := IsValidGroupID(val); len(msgs) != 0 {
 			t.Errorf("expected true for '%d': %v", val, msgs)
 		}
 	}
 
-	badValues := []int64{-1, -1003, 2147483648, 4147483647}
+	badValues := createGroupIDs(-1, -1003, 2147483648, 4147483647)
 	for _, val := range badValues {
-		if msgs := IsValidGroupId(val); len(msgs) == 0 {
+		if msgs := IsValidGroupID(val); len(msgs) == 0 {
 			t.Errorf("expected false for '%d'", val)
 		}
 	}
 }
 
-func TestIsValidUserId(t *testing.T) {
-	goodValues := []int64{0, 1, 1000, 65535, 2147483647}
+func TestIsValidUserID(t *testing.T) {
+	goodValues := createUserIDs(0, 1, 1000, 65535, 2147483647)
 	for _, val := range goodValues {
-		if msgs := IsValidUserId(val); len(msgs) != 0 {
+		if msgs := IsValidUserID(val); len(msgs) != 0 {
 			t.Errorf("expected true for '%d': %v", val, msgs)
 		}
 	}
 
-	badValues := []int64{-1, -1003, 2147483648, 4147483647}
+	badValues := createUserIDs(-1, -1003, 2147483648, 4147483647)
 	for _, val := range badValues {
-		if msgs := IsValidUserId(val); len(msgs) == 0 {
+		if msgs := IsValidUserID(val); len(msgs) == 0 {
 			t.Errorf("expected false for '%d'", val)
 		}
 	}


### PR DESCRIPTION
This PR alters some validation functions to use the dedicated types for Unix Group/User IDs. 

Relates to https://github.com/kubernetes/kubernetes/issues/38120 and https://github.com/kubernetes/kubernetes/pull/44714. API change has been approved in former thread.