### PR TITLE
Add loopback to bind IPs

### DIFF
--- a/pkg/util/net/interface.go
+++ b/pkg/util/net/interface.go
@@ -378,10 +378,10 @@ func chooseHostInterfaceFromRoute(routes []Route, nw networkInterfacer) (net.IP,
 }
 
 // If bind-address is usable, return it directly
-// If bind-address is not usable (unset, 0.0.0.0, or loopback), we will use the host's default
+// If bind-address is not usable (unset, 0.0.0.0), we will use the host's default
 // interface.
 func ChooseBindAddress(bindAddress net.IP) (net.IP, error) {
-	if bindAddress == nil || bindAddress.IsUnspecified() || bindAddress.IsLoopback() {
+	if bindAddress == nil || bindAddress.IsUnspecified() {
 		hostIP, err := ChooseHostInterface()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Currently in case IP set to localhost, it will be rediscovered from available interfaces. This blocks use-cases like localhost proxy on client side, as described in https://github.com/kubernetes/kubeadm/issues/487 
Let me know if you prefer an additional method instead of changing this one, or you have any concerns about using localhost as a bind interface (even for local testing). 