### PR TITLE
Correct the description of YAMLFramer

### DIFF
--- a/pkg/runtime/serializer/json/json.go
+++ b/pkg/runtime/serializer/json/json.go
@@ -358,7 +358,8 @@ func (jsonFramer) NewFrameReader(r io.ReadCloser) io.ReadCloser {
 	return framer.NewJSONFramedReader(r)
 }
 
-// YAMLFramer is the default JSON framing behavior, with newlines delimiting individual objects.
+// YAMLFramer is the default YAML framing behavior, with the YAML document separator (`---`
+// followed by line break) delimiting individual objects.
 var YAMLFramer = yamlFramer{}
 
 type yamlFramer struct{}


### PR DESCRIPTION
The description was for (JSON) Framer.

Sorry, we do not accept changes directly against this repository. Please see
CONTRIBUTING.md for information on where and how to contribute instead.
