### PR TITLE
Feat update stream watcher

### DIFF
--- a/pkg/watch/streamwatcher.go
+++ b/pkg/watch/streamwatcher.go
@@ -55,6 +55,7 @@ type StreamWatcher struct {
 	source   Decoder
 	reporter Reporter
 	result   chan Event
+	done     chan struct{}
 	stopped  bool
 }
 
@@ -67,6 +68,11 @@ func NewStreamWatcher(d Decoder, r Reporter) *StreamWatcher {
 		// goroutine/channel, but impossible for them to remove it,
 		// so nonbuffered is better.
 		result: make(chan Event),
+		// If the watcher is externally stopped there is no receiver anymore
+		// and the send operations on the result channel, especially the
+		// error reporting might block forever.
+		// Therefore a dedicated stop channel is used to resolve this blocking.
+		done: make(chan struct{}),
 	}
 	go sw.receive()
 	return sw
@@ -84,6 +90,7 @@ func (sw *StreamWatcher) Stop() {
 	defer sw.Unlock()
 	if !sw.stopped {
 		sw.stopped = true
+		close(sw.done)
 		sw.source.Close()
 	}
 }
@@ -116,17 +123,25 @@ func (sw *StreamWatcher) receive() {
 				if net.IsProbableEOF(err) || net.IsTimeout(err) {
 					klog.V(5).Infof("Unable to decode an event from the watch stream: %v", err)
 				} else {
-					sw.result <- Event{
+					select {
+					case <-sw.done:
+						return
+					case sw.result <- Event{
 						Type:   Error,
 						Object: sw.reporter.AsObject(fmt.Errorf("unable to decode an event from the watch stream: %v", err)),
+					}:
 					}
 				}
 			}
 			return
 		}
-		sw.result <- Event{
+		select {
+		case <-sw.done:
+			return
+		case sw.result <- Event{
 			Type:   action,
 			Object: obj,
+		}:
 		}
 	}
 }

--- a/pkg/watch/streamwatcher_test.go
+++ b/pkg/watch/streamwatcher_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	. "k8s.io/apimachinery/pkg/watch"
@@ -103,5 +104,18 @@ func TestStreamWatcherError(t *testing.T) {
 	_, ok = <-sw.ResultChan()
 	if ok {
 		t.Fatalf("unexpected open channel")
+	}
+}
+
+func TestStreamWatcherRace(t *testing.T) {
+	fd := fakeDecoder{err: fmt.Errorf("test error")}
+	fr := &fakeReporter{}
+	sw := NewStreamWatcher(fd, fr)
+	time.Sleep(10 * time.Millisecond)
+	sw.Stop()
+	time.Sleep(10 * time.Millisecond)
+	_, ok := <-sw.ResultChan()
+	if ok {
+		t.Fatalf("unexpected pending send")
 	}
 }


### PR DESCRIPTION
We are using version 1.18 of Kubernetes. Due to our own needs, we frequently call the Watch method of client-go. 
According to pprof, we found that the goroutine caused by receive method has a leak problem. 
I noticed that this issue was fixed in release-1.21, could we also cherry pick it to release-1.18+?