### PR TITLE
Handle nil receiver in Time.GoString and MicroTime.GoString

### DIFF
--- a/pkg/apis/meta/v1/micro_time.go
+++ b/pkg/apis/meta/v1/micro_time.go
@@ -207,3 +207,13 @@ func (t MicroTime) MarshalQueryParameter() (string, error) {
 
 	return t.UTC().Format(RFC3339Micro), nil
 }
+
+// GoString implements fmt.GoStringer and formats t to be printed in Go source
+// code. It handles nil receivers to prevent nil pointer dereference when the
+// embedded time.Time field is accessed through a nil *MicroTime pointer.
+func (t *MicroTime) GoString() string {
+	if t == nil {
+		return "metav1.NewMicroTime(time.Time{})"
+	}
+	return t.Time.GoString()
+}

--- a/pkg/apis/meta/v1/micro_time_test.go
+++ b/pkg/apis/meta/v1/micro_time_test.go
@@ -400,3 +400,24 @@ func TestMicroTimeRoundtripCBOR(t *testing.T) {
 		}
 	}
 }
+
+func TestMicroTimeGoString(t *testing.T) {
+	t1 := NewMicroTime(time.Now())
+	cases := []struct {
+		name string
+		x    *MicroTime
+	}{
+		{"nil", nil},
+		{"not nil", &t1},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Should not panic
+			result := c.x.GoString()
+			if len(result) == 0 {
+				t.Errorf("GoString returned empty string for %v", c.x)
+			}
+		})
+	}
+}

--- a/pkg/apis/meta/v1/time.go
+++ b/pkg/apis/meta/v1/time.go
@@ -209,3 +209,13 @@ func (t Time) MarshalQueryParameter() (string, error) {
 
 	return t.UTC().Format(time.RFC3339), nil
 }
+
+// GoString implements fmt.GoStringer and formats t to be printed in Go source
+// code. It handles nil receivers to prevent nil pointer dereference when the
+// embedded time.Time field is accessed through a nil *Time pointer.
+func (t *Time) GoString() string {
+	if t == nil {
+		return "metav1.NewTime(time.Time{})"
+	}
+	return t.Time.GoString()
+}

--- a/pkg/apis/meta/v1/time_test.go
+++ b/pkg/apis/meta/v1/time_test.go
@@ -325,3 +325,24 @@ func TestTimeRoundtripCBOR(t *testing.T) {
 		}
 	}
 }
+
+func TestTimeGoString(t *testing.T) {
+	t1 := NewTime(time.Now())
+	cases := []struct {
+		name string
+		x    *Time
+	}{
+		{"nil", nil},
+		{"not nil", &t1},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Should not panic
+			result := c.x.GoString()
+			if len(result) == 0 {
+				t.Errorf("GoString returned empty string for %v", c.x)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

Both `Time` and `MicroTime` embed `time.Time`. When a nil `*Time` or `*MicroTime` pointer is used with `fmt`'s `%#v` verb (or any `GoStringer` consumer), the inherited `time.Time.GoString()` is called, which dereferences the nil pointer to access the embedded field, causing a segfault (`EXC_BAD_ACCESS`).

Other pointer-receiver methods on these types (`IsZero`, `Before`, `Equal`) already handle nil receivers. This commit adds the same nil guard to `GoString`.

## Which issue(s) this PR fixes

This was discovered via the [Terraform Kubernetes provider](https://github.com/hashicorp/terraform-provider-kubernetes), where a nil `*metav1.Time` field in a Kubernetes resource silently crashes the provider goroutine handling gRPC `ReadResource` calls on macOS, causing the provider to hang indefinitely.

Debugger backtrace showing the crash:
```
Thread #12: EXC_BAD_ACCESS (code=1, address=0x0)
  frame #0: k8s.io/apimachinery/pkg/apis/meta/v1.(*Time).GoString + 14
```

All other goroutines are parked in `_pthread_cond_wait` → `semasleep` → `findRunnable` → `schedule`, waiting for work from the crashed goroutine that will never return.

## Special notes for your reviewer

The fix follows the existing nil-receiver pattern already used by `IsZero()`, `Before()`, and `Equal()` on the same types.

## Does this PR introduce a user-facing change?

```release-note
Fixed nil pointer dereference in metav1.Time.GoString() and metav1.MicroTime.GoString() when called on nil pointers, which could cause silent goroutine crashes in consumers like the Terraform Kubernetes provider.
```